### PR TITLE
Fixed variable length for double types

### DIFF
--- a/Sharp7.Rx.Tests/ParsingS7VariableName.feature
+++ b/Sharp7.Rx.Tests/ParsingS7VariableName.feature
@@ -31,7 +31,7 @@ Scenario: Parsing variable name for bool
 	| Db      | 5    | 887   | 20     | 0   | String   |
 	| Db      | 506  | 216   | 1      | 0   | Byte     |
 	| Db      | 506  | 216   | 5      | 0   | Byte     |
-	| Db      | 506  | 216   | 0      | 0   | Double   |
+	| Db      | 506  | 216   | 4      | 0   | Double   |
 	| Db      | 506  | 216   | 4      | 0   | DInteger |
 	| Db      | 506  | 216   | 2      | 0   | Integer  |
 	| Db      | 506  | 216   | 2      | 0   | Integer  |

--- a/Sharp7.Rx.Tests/ParsingS7VariableName.feature.cs
+++ b/Sharp7.Rx.Tests/ParsingS7VariableName.feature.cs
@@ -186,7 +186,7 @@ this.ScenarioInitialize(scenarioInfo);
                         "Db",
                         "506",
                         "216",
-                        "0",
+                        "4",
                         "0",
                         "Double"});
             table2.AddRow(new string[] {

--- a/Sharp7.Rx/S7VariableNameParser.cs
+++ b/Sharp7.Rx/S7VariableNameParser.cs
@@ -74,6 +74,10 @@ namespace Sharp7.Rx
                 {
                     s7VariableAddress.Length = 8;
                 }
+                else if (type == DbType.Double)
+                {
+                    s7VariableAddress.Length = 4;
+                }
 
                 return s7VariableAddress;
             }


### PR DESCRIPTION
- added default value for variables of type double (float in PLCs)

this error avoid getting notification from type float or double.